### PR TITLE
Make navbar links white again

### DIFF
--- a/app/ui/site/syles.css
+++ b/app/ui/site/syles.css
@@ -1,5 +1,5 @@
 .navbar-links {
-  @apply rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white;
+  @apply rounded-md px-3 py-2 text-sm font-medium text-white hover:bg-gray-700 hover:text-white;
 }
 
 .navbar-links-mobile {


### PR DESCRIPTION
The [homepage](https://ts4nfdi.github.io/homepage/) had white navbar links, these are more legible and footer links are white too. I stumbled upon this on configuring Cocoda TS4NFDI instance with same colors like other TS4NFDI sites.