### PR TITLE
ci(cd): add production deployment

### DIFF
--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -1,64 +1,28 @@
-name: Release Service Portal
-
+name: Deployment to production
+concurrency: production
 on:
-  push:
-    branches: ['main']
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Do you really want to update the production instance'
+        required: false
+        type: boolean
+      image_sha:
+        description: 'Image SHA ID, Optional '
+        type: string
+        required: false
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   KUBECONFIG: .kube/config
-  KUBECONFIG_FILE: ${{ secrets.KUBECONFIG }}
+  KUBECONFIG_FILE: ${{ secrets.KUBECONFIG_PROD }}
 
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
-    environment: release 
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          secrets: |
-            npm_token=${{ secrets.NPM_TOKEN }}
-      
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
   deploy_main:
     environment: release-k8s
-    needs: build-and-push-image
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Set up Kubernetes config
         run: |
           mkdir -p .kube
@@ -82,6 +46,13 @@ jobs:
         run: |
           kubectl create secret generic ts4nfdi-service-portal-smtp-password \
             --from-literal=SMTP_PASSWORD=${{ secrets.SMTP_PASSWORD }} \
+            --namespace='ts4nfdi' \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create K8s secret for SMTP_PORT
+        run: |
+          kubectl create secret generic ts4nfdi-service-portal-smtp-port \
+            --from-literal=SMTP_PASSWORD=${{ vars.SMTP_PORT }} \
             --namespace='ts4nfdi' \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -109,7 +80,7 @@ jobs:
       - name: Create K8s secret for CONTACT_RECV_EMAIL
         run: |
           kubectl create secret generic ts4nfdi-service-portal-contact-recv-email \
-            --from-literal=CONTACT_RECV_EMAIL=${{ secrets.CONTACT_RECV_EMAIL }} \
+            --from-literal=CONTACT_RECV_EMAIL=${{ vars.CONTACT_RECV_EMAIL }} \
             --namespace='ts4nfdi' \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -139,13 +110,12 @@ jobs:
         with:
           helmv3: 3.12.0
           command: |
-            kubectl get nodes
             helmv3 repo add service-portal-deployment https://ts4nfdi.github.io/service-portal-deployment/
             helmv3 repo update
-            helmv3 upgrade ts4nfdi-service-portal \
-              --install \
-              --namespace='ts4nfdi' \
-              --set-json='ingress.dns="ts4nfdi-service-portal.qa.km.k8s.zbmed.de"'  \
-              --set-json='images.ui="ghcr.io/ts4nfdi/service-portal:main"' \
-              --set-json='ingress.path="/"' \
-              service-portal-deployment/service-portal-ui
+            helmv3 upgrade ts4nfdi-service-portal  \
+            --install \
+            --namespace='ts4nfdi' \
+            --set-json='ingress.dns="ts4nfdi-service-portal.prod.km.k8s.zbmed.de"'  \
+            --set-json='images.ui="ghcr.io/ts4nfdi/service-portal:main"' \
+            --set-json='ingress.path="/"' \
+            service-portal-deployment/service-portal-ui


### PR DESCRIPTION
Add production deployment and use all secrets and variables from the GitHub env.

Production deployment has to be manually triggered in Actions > Deployment to production > Run workflow. Image SHA ID is optional, default is latest main.