### PR TITLE
Ci/generate image tag

### DIFF
--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -116,7 +116,7 @@ jobs:
             --install \
             --namespace='ts4nfdi' \
             --set-json='ingress.dns="ts4nfdi-service-portal.prod.km.k8s.zbmed.de"'  \
-            --set-json='images.ui="ghcr.io/ts4nfdi/service-portal:main"' \
+            --set-json='images.ui="ghcr.io/${{ github.repository }}:${{ inputs.image_sha|| github.sha }}"' \
             --set-json='ingress.path="/"' \
             --set-json='ingress.enableSSL="true"'  \
             --set-json='ingress.certIssuer="letsencrypt-prod"'  \

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -118,4 +118,6 @@ jobs:
             --set-json='ingress.dns="ts4nfdi-service-portal.prod.km.k8s.zbmed.de"'  \
             --set-json='images.ui="ghcr.io/ts4nfdi/service-portal:main"' \
             --set-json='ingress.path="/"' \
+            --set-json='ingress.enableSSL="true"'  \
+            --set-json='ingress.certIssuer="letsencrypt-prod"'  \
             service-portal-deployment/service-portal-ui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - id: generate-image-tag
+        name: Generate Image Tag
+        env:
+          # The branch or tag name that triggered the workflow
+          ref_name: "${{ github.ref_name }}"
+          # The source branch of a pull request (only set in PRs)
+          head_ref: "${{ github.head_ref }}"
+        # Replace slashes in branch names, determine final image name, set output variable imageTag
+        run: |
+          head_ref="${head_ref/\//-}"
+          tag="${head_ref:-${ref_name}}"
+          tag="${tag#v}"
+          echo "imageTag=tag" >> "$GITHUB_OUTPUT"
+
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
@@ -42,7 +56,10 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          # use a) human-readable and b) immutable tag
+          tags: |
+            ghcr.io/${{ github.repository }}/backend:${{ steps.generate-image-tag.outputs.imageTag }}
+            ghcr.io/${{ github.repository }}/backend:${{ github.event.pull_request.head.sha || github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
             npm_token=${{ secrets.NPM_TOKEN }}
@@ -146,6 +163,6 @@ jobs:
               --install \
               --namespace='ts4nfdi' \
               --set-json='ingress.dns="ts4nfdi-service-portal.qa.km.k8s.zbmed.de"'  \
-              --set-json='images.ui="ghcr.io/ts4nfdi/service-portal:main"' \
+              --set-json='images.ui="ghcr.io/${{ github.repository }}:${{ github.event.pull_request.head.sha || github.sha }}"' \
               --set-json='ingress.path="/"' \
               service-portal-deployment/service-portal-ui


### PR DESCRIPTION
Generates the image tag from either the branch name that triggered the workflow or the source branch of a pull request. Produces two image names - a human readable main tag and an unique tag. The unique tag is used for the K8s deployment.

Please check if this conflicts with the former naming strategy and metadata.
